### PR TITLE
Better EXE: standardized wrapper script, which validates hash of downloaded script

### DIFF
--- a/PowershellStub.vcxproj
+++ b/PowershellStub.vcxproj
@@ -29,26 +29,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/PowershellStub.vcxproj
+++ b/PowershellStub.vcxproj
@@ -160,7 +160,7 @@
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <SetChecksum>true</SetChecksum>
       <MergeSections>.pdata=.text</MergeSections>
-      <SectionAlignment>128</SectionAlignment>
+      <SectionAlignment>64</SectionAlignment>
       <StackReserveSize>32768</StackReserveSize>
       <HeapReserveSize>32768</HeapReserveSize>
       <StackCommitSize>32768</StackCommitSize>

--- a/PowershellStub.vcxproj
+++ b/PowershellStub.vcxproj
@@ -74,9 +74,13 @@
     <GenerateManifest>false</GenerateManifest>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
@@ -88,7 +92,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
@@ -104,19 +108,30 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <SDLCheck>true</SDLCheck>
+      <WarningLevel>Level4</WarningLevel>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <StringPooling>true</StringPooling>
+      <ExceptionHandling>false</ExceptionHandling>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <SupportJustMyCode>false</SupportJustMyCode>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EntryPointSymbol>main</EntryPointSymbol>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
+      <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);chkstk.obj</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
@@ -131,6 +146,9 @@
       <DebugInformationFormat>None</DebugInformationFormat>
       <CreateHotpatchableImage>false</CreateHotpatchableImage>
       <StringPooling>true</StringPooling>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
+      <AdditionalOptions>/Gs32768 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -145,6 +163,8 @@
       <SectionAlignment>128</SectionAlignment>
       <StackReserveSize>32768</StackReserveSize>
       <HeapReserveSize>32768</HeapReserveSize>
+      <StackCommitSize>32768</StackCommitSize>
+      <EnableUAC>false</EnableUAC>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -39,7 +39,7 @@ Command line syntax:
 | `WhatIf` *or* `WhatIfRaw` | **(optional)** if specified, just prints the command line that would be used. |
 | *&lt;InstallMode&gt;* | One of `Interactive`, `Silent`, or `SilentWithProgress`. (Corresponds to winget install modes.) |
 | *&lt;ScriptURL&gt;* | URL from which to download the PowerShell script to run. |
-| *&lt;ExpectedScriptHash&gt;* | Expected SHA256 hash of the install script (encoded as UTF16), in hex. If the downloaded script does not match this hash, it will not be run. |
+| *&lt;ExpectedScriptHash&gt;* | Expected SHA256 hash of the install script (encoded as UTF8), in hex. If the downloaded script does not match this hash, it will not be run. |
 | *&lt;OptionalArgs&gt;* | **optional** additional arguments to pass along to the script. |
 
 `PowerShellStub.exe` is *extremely* simple--it only parses its arguments, then delegates all the "real work" (such as downloading the install script and verifying its hash) to `powershell.exe`, via a small "wrapper script" that is provided directly on the command line. You can use the `WhatIf` option to see what would be run.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -2,20 +2,111 @@
 
 ## What is it?
 
-A ***tiny*** (less than 2k!) EXE that forwards its arguments on to the Windows built-in `powershell.exe` (legacy Windows PowerShell 5.1), then waits for it to exit, and returns `powershell.exe`'s return code as its own.
+A ***tiny*** (8k) EXE that launches the Windows built-in `powershell.exe`
+(legacy Windows PowerShell 5.1) with a wrapper script that downloads, verifies,
+and runs another script, waits for `powershell.exe` to exit, and returns
+`powershell.exe`'s return code as its own.
 
 ## But... WHY is it?
 
-I was creating a `winget` package manifest, and the "installer" that I wanted to wrap was just a script... but `winget` needs to get something that it can *run* (executing a `.ps1` just opens it in a text editor), and it really wants to download that thing from the interwebs. So I provided it something to run, downloadable, in the form of `PowershellStub.exe`. You are welcome to use it, too, if you like (see [the WingetPathUpdater manifest](https://github.com/jazzdelightsme/WingetPathUpdater/blob/main/manifests/j/jazzdelightsme/WingetPathUpdater/1.0/jazzdelightsme.WingetPathUpdater.installer.yaml) for example usage).
+This is useful as an "installer" EXE for winget, where the actual install logic
+is implemented in a (downloadable) PowerShell script.
+
+For a `winget` package, `winget` needs to get something that it can *run*
+(executing a `.ps1` just opens it in a text editor), and it really wants to
+download that thing from the interwebs. This EXE supplies that.
+
+In general, the policy for `winget` packages is to avoid executing dynamic
+content, hence "script installers" are not natively supported. Although this
+EXE allows implementing an installer in script, it aims to follow the spirit of
+that policy: just like `winget` verifies hashes of EXEs, using
+`PowerShellStub.exe` will verify the hash of your installl script (as well as a
+signature, if it exists), only executing the script if its hash matches what
+was specified on the command line (in your `winget` package manifest).
+
+You are welcome to use it too, if you like (see [the WingetPathUpdater
+manifest](https://github.com/jazzdelightsme/WingetPathUpdater/blob/main/manifests/j/jazzdelightsme/WingetPathUpdater/1.3/jazzdelightsme.WingetPathUpdater.installer.yaml)
+for example usage).
+
+## Details
+
+Command line syntax:
+
+`PowershellStub.exe [WhatIf|WhatIfRaw] <InstallMode> <ScriptURL> <ExpectedScriptHash> [<OptionalArgs>`
+
+| Option | Description |
+|-------:|:------------|
+| `WhatIf` *or* `WhatIfRaw` | **(optional)** if specified, just prints the command line that would be used. |
+| *&lt;InstallMode&gt;* | One of `Interactive`, `Silent`, or `SilentWithProgress`. (Corresponds to winget install modes.) |
+| *&lt;ScriptURL&gt;* | URL from which to download the PowerShell script to run. |
+| *&lt;ExpectedScriptHash&gt;* | Expected SHA256 hash of the install script (encoded as UTF16), in hex. If the downloaded script does not match this hash, it will not be run. |
+| *&lt;OptionalArgs&gt;* | **optional** additional arguments to pass along to the script. |
+
+`PowerShellStub.exe` is *extremely* simple--it only parses its arguments, then delegates all the "real work" (such as downloading the install script and verifying its hash) to `powershell.exe`, via a small "wrapper script" that is provided directly on the command line. You can use the `WhatIf` option to see what would be run.
+
+For example, this `PowerShellStub.exe` command line:
+
+`PowershellStub.exe WhatIf Interactive https://example.com/install-the-thing 37b91cb6eebc34c965ac3bbfc59a9ca64738054b7d31131e59698a86e38613d3 -MyCustomArg Something -Blah 'Whatever'`
+
+Shows that it would run the following "wrapper script" (pretty-printed; use `WhatIfRaw` instead of `WhatIf` to see the raw `lpCommandLine` that would be passed to `CreateProcess`):
+
+```powershell
+    powershell.exe -NoProfile -ExecutionPolicy RemoteSigned -Command $env:PSModulePath = $null
+    Set-StrictMode -Version Latest
+    try
+    {
+        $theScript = (iwr https://example.com/install-the-thing$env:_POWERSHELL_STUB_TEST_URL_SUFFIX -UseBasic -EA Stop).Content
+        $bytes = [System.Text.Encoding]::Unicode.GetBytes( $theScript )
+        $hash = ([Security.Cryptography.SHA256]::Create().ComputeHash( $bytes ) | %{$_.ToString('x2')}) -join ''
+        $expectedHash = '37b91cb6eebc34c965ac3bbfc59a9ca64738054b7d31131e59698a86e38613d3'
+        if( $hash -ne $expectedHash )
+        {
+            throw "Hash mismatch: expected $expectedHash but got $hash"
+        }
+
+        $sig = Get-AuthenticodeSignature -Source 'theScript.ps1' -Content $bytes
+        if( ($sig.Status -ne 'Valid') -and ($sig.Status -ne 'NotSigned') )
+        {
+            throw "Signature error: $($sig.Status)"
+        }
+
+        Invoke-Expression ". {$theScript} -Interactive -MyCustomArg Something -Blah Whatever -EA Stop"
+    }
+    catch
+    {
+        Write-Host $_ -Fore Red
+        $rsp = Read-Host 'pausing... press [enter] to finish'
+        if( $rsp -eq 'd' )
+        {
+            $host.EnterNestedPrompt()
+        }
+
+        throw
+    }
+```
+
+Notable details:
+
+ * The script is executed with `StrictMode` on, `RemoteSigned` execution policy, and `-NoProfile`.
+ * For `Silent` and `SilentWithProgress` modes, `-NonInteractive` is also passed.
+ * The value of the environment variable `$env:_POWERSHELL_STUB_TEST_URL_SUFFIX` is appended to the ScriptUrl. This is handy for testing a new version of the install script without having to update your winget package.
+ * The install script is executed directly from memory; not saved to a temporary file.
+ * The winget install mode is passed as a switch parameter to the script (e.g. `-Interactive`), followed by the optional parameters, followed by `-EA Stop` (all errors are treated as terminating errors).
+ * The downloaded install script does not have to be signed, but if it is, the signature must be valid.
+ * If an error occurs in Interactive mode, the wrapper script pauses so you can read the error. If you enter `d` at the prompt, you'll enter a nested shell so you can poke around more (run `exit` to quit the nested shell).
+ * `PowerShellStub.exe` returns the return code of the `powershell.exe` process. The exit code for an uncaught exception is `1`.
 
 ## How'd you get it so small?
 
-If you search for information about how to create tiny EXEs, you'll see that I didn't go nearly as far as some people do! But I'm not trying to win a contest; anything under 4k would have been fine with me, so that the whole image can fit into a single page of memory.
+If you search for information about how to create tiny EXEs, you'll see that I
+didn't go nearly as far as some people do! But I'm not trying to win a contest;
+any small number of kb would be fine with me, so that the whole image can fit
+into just a few pages of memory.
 
-Techniques I used:
+Some techniques I used:
  * All the compiler/linker optimization switches on, and favoring "size" over "speed".
  * Don't link any default libs (not even the C runtime--`main` gets no args!).
  * Combine the `.pdata` section with the `.text` section.
- * Reduced section alignment (128).
+ * Reduced section alignment (64).
  * Turn off unneeded things (randomized base address, debug info, etc.).
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -56,7 +56,7 @@ Shows that it would run the following "wrapper script" (pretty-printed; use `Wha
     try
     {
         $theScript = (iwr https://example.com/install-the-thing$env:_POWERSHELL_STUB_TEST_URL_SUFFIX -UseBasic -EA Stop).Content
-        $bytes = [System.Text.Encoding]::Unicode.GetBytes( $theScript )
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes( $theScript )
         $hash = ([Security.Cryptography.SHA256]::Create().ComputeHash( $bytes ) | %{$_.ToString('x2')}) -join ''
         $expectedHash = '37b91cb6eebc34c965ac3bbfc59a9ca64738054b7d31131e59698a86e38613d3'
         if( $hash -ne $expectedHash )

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -20,7 +20,7 @@ In general, the policy for `winget` packages is to avoid executing dynamic
 content, hence "script installers" are not natively supported. Although this
 EXE allows implementing an installer in script, it aims to follow the spirit of
 that policy: just like `winget` verifies hashes of EXEs, using
-`PowerShellStub.exe` will verify the hash of your installl script (as well as a
+`PowershellStub.exe` will verify the hash of your install script (as well as a
 signature, if it exists), only executing the script if its hash matches what
 was specified on the command line (in your `winget` package manifest).
 
@@ -32,7 +32,7 @@ for example usage).
 
 Command line syntax:
 
-`PowershellStub.exe [WhatIf|WhatIfRaw] <InstallMode> <ScriptURL> <ExpectedScriptHash> [<OptionalArgs>`
+`PowershellStub.exe [WhatIf|WhatIfRaw] <InstallMode> <ScriptURL> <ExpectedScriptHash> [<OptionalArgs>]`
 
 | Option | Description |
 |-------:|:------------|
@@ -42,9 +42,9 @@ Command line syntax:
 | *&lt;ExpectedScriptHash&gt;* | Expected SHA256 hash of the install script (encoded as UTF8), in hex. If the downloaded script does not match this hash, it will not be run. |
 | *&lt;OptionalArgs&gt;* | **optional** additional arguments to pass along to the script. |
 
-`PowerShellStub.exe` is *extremely* simple--it only parses its arguments, then delegates all the "real work" (such as downloading the install script and verifying its hash) to `powershell.exe`, via a small "wrapper script" that is provided directly on the command line. You can use the `WhatIf` option to see what would be run.
+`PowershellStub.exe` is *extremely* simple--it only parses its arguments, then delegates all the "real work" (such as downloading the install script and verifying its hash) to `powershell.exe`, via a small "wrapper script" that is provided directly on the command line. You can use the `WhatIf` option to see what would be run.
 
-For example, this `PowerShellStub.exe` command line:
+For example, this `PowershellStub.exe` command line:
 
 `PowershellStub.exe WhatIf Interactive https://example.com/install-the-thing 37b91cb6eebc34c965ac3bbfc59a9ca64738054b7d31131e59698a86e38613d3 -MyCustomArg Something -Blah 'Whatever'`
 
@@ -94,7 +94,7 @@ Notable details:
  * The winget install mode is passed as a switch parameter to the script (e.g. `-Interactive`), followed by the optional parameters, followed by `-EA Stop` (all errors are treated as terminating errors).
  * The downloaded install script does not have to be signed, but if it is, the signature must be valid.
  * If an error occurs in Interactive mode, the wrapper script pauses so you can read the error. If you enter `d` at the prompt, you'll enter a nested shell so you can poke around more (run `exit` to quit the nested shell).
- * `PowerShellStub.exe` returns the return code of the `powershell.exe` process. The exit code for an uncaught exception is `1`.
+ * `PowershellStub.exe` returns the return code of the `powershell.exe` process. The exit code for an uncaught exception is `1`.
 
 ## How'd you get it so small?
 

--- a/main.cpp
+++ b/main.cpp
@@ -5,10 +5,10 @@
 
 #include <Windows.h>
 
-inline wchar_t* SkipTillAfterQuote( wchar_t* str )
+inline char8_t* SkipTillAfterQuote( char8_t* str )
 {
     while( *str &&
-           (*str != L'"') )
+           (*str != '"') )
     {
         str++;
     }
@@ -16,7 +16,7 @@ inline wchar_t* SkipTillAfterQuote( wchar_t* str )
     return ++str;
 } // end SkipTillAfterQuote()
 
-inline wchar_t* SkipUntilWhitespace( wchar_t* str )
+inline char8_t* SkipUntilWhitespace( char8_t* str )
 {
     while( *str &&
            ((*str != ' ') && (*str != '\t')) )
@@ -27,7 +27,7 @@ inline wchar_t* SkipUntilWhitespace( wchar_t* str )
     return str;
 } // end SkipUntilWhitespace()
 
-inline wchar_t* SkipUntilNotWhitespace( wchar_t* str )
+inline char8_t* SkipUntilNotWhitespace( char8_t* str )
 {
     while( *str &&
            ((*str == ' ') || (*str == '\t')) )
@@ -41,11 +41,11 @@ inline wchar_t* SkipUntilNotWhitespace( wchar_t* str )
 
 // Returns a pointer to the part of the current process command line immediately after the
 // EXE.
-inline wchar_t* FindTheRestOfTheCommandLine()
+inline char8_t* FindTheRestOfTheCommandLine()
 {
-    wchar_t* str = GetCommandLine();
+    char8_t* str = (char8_t*) GetCommandLineA();
 
-    if( str[ 0 ] == L'"' )
+    if( str[ 0 ] == '"' )
     {
         str = SkipTillAfterQuote( &str[ 1 ] );
     }
@@ -57,7 +57,7 @@ inline wchar_t* FindTheRestOfTheCommandLine()
     return str;
 } // end FindTheRestOfTheCommandLine()
 
-inline wchar_t* CopyStr( wchar_t* dest, const wchar_t* src, const wchar_t* pastDestEnd )
+inline char8_t* CopyStr( char8_t* dest, const char8_t* src, const char8_t* pastDestEnd )
 {
     // The -1 is to leave room for the terminating null.
     while( (dest < (pastDestEnd - 1)) && *src )
@@ -76,7 +76,7 @@ HANDLE g_hStdOut = 0;
 
 // TODO: does this really evaluate at compile-time, or do I need to switch to a recursive
 // method?
-constexpr DWORD MyWcslen( const wchar_t* s )
+constexpr DWORD MyWcslen( const char8_t* s )
 {
     DWORD cch = 0;
     while( *s )
@@ -87,35 +87,24 @@ constexpr DWORD MyWcslen( const wchar_t* s )
     return cch;
 }
 
-void Print( const wchar_t* s )
+void Print( const char8_t* s )
 {
-    WriteConsoleW( g_hStdOut, s, MyWcslen( s ), nullptr, nullptr );
+    WriteConsoleA( g_hStdOut, s, MyWcslen( s ), nullptr, nullptr );
 } // end Print()
 
-int MyStrCmpI( const wchar_t* s1, const wchar_t* s2 )
+int MyStrCmpI( const char8_t* s1, const char8_t* s2 )
 {
-    int ret = CompareStringOrdinal(s1, -1, s2, -1, TRUE);
-
-    if( !ret )
-    {
-        DWORD dwErr = GetLastError();
-        Print( L"Something went wrong.");
-        ExitProcess(dwErr);
-        //return 0; // unreachable
-    }
-
-    // From CompareStringOrdinal documentation: "the value 2 can be subtracted
-    // from a nonzero return value. Then, the meaning of <0, ==0, and >0 is
-    // consistent with the C runtime."
-    return ret - 2;
+    return lstrcmpiA( (const char*) s1, (const char*) s2 );
 }
 
 int main() // no C runtime, so no args here
 {
+    SetConsoleCP(CP_UTF8);
+    SetConsoleOutputCP(CP_UTF8);
     g_hStdOut = GetStdHandle( STD_OUTPUT_HANDLE );
- // Print( L"Well hello there.\n" );
+ // Print( "Well hello there.\n" );
 
-    wchar_t* commandLineArgs = FindTheRestOfTheCommandLine();
+    char8_t* commandLineArgs = FindTheRestOfTheCommandLine();
 
     // Expected arguments:
     //
@@ -126,12 +115,12 @@ int main() // no C runtime, so no args here
     // Additional arguments are optional and will be passed along to the script.
     //
 
-    wchar_t* cursor = commandLineArgs;
+    char8_t* cursor = commandLineArgs;
 
 #define EXPECT_MORE_CMDLINE \
     if( !*cursor ) \
     { \
-        Print( L"Expected more on the command line." ); \
+        Print( u8"Expected more on the command line." ); \
         ExitProcess( (UINT) -1 ); \
     } \
 
@@ -141,55 +130,55 @@ int main() // no C runtime, so no args here
 
     EXPECT_MORE_CMDLINE
 
-    *cursor++ = L'\0';
+    *cursor++ = '\0';
     cursor = SkipUntilNotWhitespace( cursor );
 
-    wchar_t* installMode = cursor;
+    char8_t* installMode = cursor;
 
     cursor = SkipUntilWhitespace( cursor );
 
     EXPECT_MORE_CMDLINE
 
-    *cursor++ = L'\0';
+    *cursor++ = '\0';
     cursor = SkipUntilNotWhitespace( cursor );
 
-    wchar_t* scriptUrl = cursor;
+    char8_t* scriptUrl = cursor;
 
     cursor = SkipUntilWhitespace( cursor );
 
     EXPECT_MORE_CMDLINE
 
-    *cursor++ = L'\0';
+    *cursor++ = '\0';
     cursor = SkipUntilNotWhitespace( cursor );
 
-    wchar_t* expectedScriptHash = cursor;
+    char8_t* expectedScriptHash = cursor;
 
     // *Optional* arguments.
     cursor = SkipUntilWhitespace( cursor );
 
     if( *cursor )
     {
-        *cursor++ = L'\0';
+        *cursor++ = '\0';
         cursor = SkipUntilNotWhitespace( cursor );
     }
 
-    wchar_t* optionalArgs = cursor;
+    char8_t* optionalArgs = cursor;
 
-//  Print( L"Install mode: " );
+//  Print( u8"Install mode: " );
 //  Print( installMode );
-//  Print( L"\n" );
+//  Print( u8"\n" );
 
-//  Print( L"Script URL: " );
+//  Print( u8"Script URL: " );
 //  Print( scriptUrl );
-//  Print( L"\n" );
+//  Print( u8"\n" );
 
-//  Print( L"Expected script hash: " );
+//  Print( u8"Expected script hash: " );
 //  Print( expectedScriptHash );
-//  Print( L"\n" );
+//  Print( u8"\n" );
 
-    const wchar_t c_Silent[] = L"Silent";
-    const wchar_t c_SilentWithProgress[] = L"SilentWithProgress";
-    const wchar_t c_Interactive[] = L"Interactive";
+    const char8_t c_Silent[] = u8"Silent";
+    const char8_t c_SilentWithProgress[] = u8"SilentWithProgress";
+    const char8_t c_Interactive[] = u8"Interactive";
 
     bool bIsSilent = 0 == MyStrCmpI( installMode, c_Silent );
     bool bIsSilentWithProgress = 0 == MyStrCmpI( installMode, c_SilentWithProgress );
@@ -197,68 +186,68 @@ int main() // no C runtime, so no args here
 
     if( !bIsSilent && !bIsSilentWithProgress && !bIsInteractive )
     {
-        Print( L"Install mode must be one of Silent, SilentWithProgress, or Interactive. Not '" );
+        Print( u8"Install mode must be one of Silent, SilentWithProgress, or Interactive. Not '" );
         Print( installMode );
-        Print( L"'.\n" );
+        Print( u8"'.\n" );
         ExitProcess( (UINT) - 1);
         //return -1;
     }
 
 //  if( bIsSilent )
 //  {
-//      Print( L"Silent mode.\n" );
+//      Print( u8"Silent mode.\n" );
 //  }
 
 //  if( bIsSilentWithProgress )
 //  {
-//      Print( L"SilentWithProgress mode.\n" );
+//      Print( u8"SilentWithProgress mode.\n" );
 //  }
 
 //  if( bIsInteractive )
 //  {
-//      Print( L"Interactive mode.\n" );
+//      Print( u8"Interactive mode.\n" );
 //  }
 
-    wchar_t newCmdLine[ 4096 ];
-    wchar_t* dst = newCmdLine;
-    const wchar_t* pastEnd = &newCmdLine[ _countof( newCmdLine ) ];
+    char8_t newCmdLine[ 4096 ];
+    char8_t* dst = newCmdLine;
+    const char8_t* pastEnd = &newCmdLine[ _countof( newCmdLine ) ];
 
-    const wchar_t cmdFrag0[] = L" -NoProfile -ExecutionPolicy RemoteSigned -Command $env:PSModulePath = $null ; "
-                               L"try { "
-                                   L"$theScript = (iwr ";
+    const char8_t cmdFrag0[] = u8" -NoProfile -ExecutionPolicy RemoteSigned -Command $env:PSModulePath = $null ; "
+                               u8"try { "
+                                   u8"$theScript = (iwr ";
 
-    const wchar_t cmdFrag1[] =     L"$env:_POWERSHELL_STUB_TEST_URL_SUFFIX -UseBasic -EA Stop).Content ; "
-                                   L"$bytes = [System.Text.Encoding]::Unicode.GetBytes( $theScript ) ; "
-                                   L"$hash = ([Security.Cryptography.SHA256]::Create().ComputeHash( $bytes ) | %{ $_.ToString('x2') }) -join '' ; "
-                                   L"$expectedHash = '";
+    const char8_t cmdFrag1[] =     u8"$env:_POWERSHELL_STUB_TEST_URL_SUFFIX -UseBasic -EA Stop).Content ; "
+                                   u8"$bytes = [System.Text.Encoding]::Unicode.GetBytes( $theScript ) ; "
+                                   u8"$hash = ([Security.Cryptography.SHA256]::Create().ComputeHash( $bytes ) | %{ $_.ToString('x2') }) -join '' ; "
+                                   u8"$expectedHash = '";
 
-    const wchar_t cmdFrag2[] =     L"' ; "
-                                   L"if( $hash -ne $expectedHash ) "
-                                   L"{ "
-                                       L"throw \\\"Hash mismatch: expected $expectedHash but got $hash\\\" "
-                                   L"} ; "
-                                   L"$sig = Get-AuthenticodeSignature -Source 'theScript.ps1' -Content $bytes ; "
-                                   L"if( ($sig.Status -ne 'Valid') -and ($sig.Status -ne 'NotSigned') ) "
-                                   L"{ "
-                                       L"throw \\\"Signature error: $($sig.Status)\\\" "
-                                   L"} ; "
-                                   L"Invoke-Expression \\\". { $theScript } -";
+    const char8_t cmdFrag2[] =     u8"' ; "
+                                   u8"if( $hash -ne $expectedHash ) "
+                                   u8"{ "
+                                       u8"throw \\\"Hash mismatch: expected $expectedHash but got $hash\\\" "
+                                   u8"} ; "
+                                   u8"$sig = Get-AuthenticodeSignature -Source 'theScript.ps1' -Content $bytes ; "
+                                   u8"if( ($sig.Status -ne 'Valid') -and ($sig.Status -ne 'NotSigned') ) "
+                                   u8"{ "
+                                       u8"throw \\\"Signature error: $($sig.Status)\\\" "
+                                   u8"} ; "
+                                   u8"Invoke-Expression \\\". { $theScript } -";
 
-    const wchar_t cmdFrag3[] =     L" -EA Stop\\\" ; "
-                               L"} catch { ";
+    const char8_t cmdFrag3[] =     u8" -EA Stop\\\" ; "
+                               u8"} catch { ";
 
-    const wchar_t cmdFrag4_Interactive[] =
-                                   L"Write-Host $_ -Fore Red ; "
-                                   L"$rsp = Read-Host 'pausing... [enter] to finish' ; "
-                                   L"if( $rsp -eq 'd' ) { $host.EnterNestedPrompt() } ; "
-                                   L"throw"
-                               L"}";
+    const char8_t cmdFrag4_Interactive[] =
+                                   u8"Write-Host $_ -Fore Red ; "
+                                   u8"$rsp = Read-Host 'pausing... [enter] to finish' ; "
+                                   u8"if( $rsp -eq 'd' ) { $host.EnterNestedPrompt() } ; "
+                                   u8"throw"
+                               u8"}";
 
-    const wchar_t cmdFrag4_Silent[] =
-                                   L"Write-Host $_ -Fore Red ; "
-                                   L"Start-Sleep -Seconds 5 ; " // Give people a chance to at least see the error.
-                                   L"throw"
-                               L"}";
+    const char8_t cmdFrag4_Silent[] =
+                                   u8"Write-Host $_ -Fore Red ; "
+                                   u8"Start-Sleep -Seconds 5 ; " // Give people a chance to at least see the error.
+                                   u8"throw"
+                               u8"}";
 
     dst = CopyStr( dst, cmdFrag0, pastEnd );
     dst = CopyStr( dst, scriptUrl, pastEnd );
@@ -266,7 +255,7 @@ int main() // no C runtime, so no args here
     dst = CopyStr( dst, expectedScriptHash, pastEnd );
     dst = CopyStr( dst, cmdFrag2, pastEnd );
     dst = CopyStr( dst, installMode, pastEnd );
-    dst = CopyStr( dst, L" ", pastEnd);
+    dst = CopyStr( dst, u8" ", pastEnd);
     dst = CopyStr( dst, optionalArgs, pastEnd);
     dst = CopyStr( dst, cmdFrag3, pastEnd );
 
@@ -279,19 +268,19 @@ int main() // no C runtime, so no args here
         dst = CopyStr( dst, cmdFrag4_Silent, pastEnd );
     }
 
- // Print( L"\nCommandline: " );
+ // Print( u8"\nCommandline: " );
  // Print( newCmdLine );
- // Print( L"\n\n" );
+ // Print( u8"\n\n" );
 
     PROCESS_INFORMATION pi = { };
-    STARTUPINFOW si;
+    STARTUPINFOA si;
     SecureZeroMemory( &si, sizeof( si ) ); // compiler complained about no memset; whatevs
     si.cb = (DWORD) sizeof( si );
 
-    const wchar_t* wszPowershellExe = L"C:\\Windows\\system32\\WindowsPowerShell\\v1.0\\powershell.exe";
+    const char* szPowershellExe = "C:\\Windows\\system32\\WindowsPowerShell\\v1.0\\powershell.exe";
 
-    BOOL bItWorked = CreateProcessW( wszPowershellExe,
-                                     newCmdLine,
+    BOOL bItWorked = CreateProcessA( szPowershellExe,
+                                     (char*) newCmdLine,
                                      nullptr,   // lpProcessAttributes
                                      nullptr,   // lpThreadAttributes
                                      TRUE,      // bInheritHandles

--- a/main.cpp
+++ b/main.cpp
@@ -86,7 +86,7 @@ HANDLE g_hStdOut = 0;
 
 void Print( const char8_t* s )
 {
-    WriteConsoleA( g_hStdOut, s, MyStrLen( s ), nullptr, nullptr );
+    WriteFile( g_hStdOut, s, MyStrLen( s ), nullptr, nullptr );
 }
 
 int MyStrCmpI( const char8_t* s1, const char8_t* s2 )

--- a/main.cpp
+++ b/main.cpp
@@ -138,7 +138,7 @@ bool _HandleUsageRequest( const char8_t* installMode )
                u8"If an error occurs in Interactive mode, the wrapper script pauses so you can read the error. If you enter 'd'\n"
                u8"at the prompt, you'll enter a nested shell so you can poke around more (run 'exit' to quit the nested shell).\n"
                u8"\n"
-               u8"PowerShellStub.exe returns the return code of the powershell.exe process. The exit code for an uncaught\n"
+               u8"PowershellStub.exe returns the return code of the powershell.exe process. The exit code for an uncaught\n"
                u8"exception is 1.\n"
                u8"\n"
              );

--- a/main.cpp
+++ b/main.cpp
@@ -117,7 +117,7 @@ bool _HandleUsageRequest( const char8_t* installMode )
                u8"\n"
                u8"    ScriptURL: URL from which to download the PowerShell script to run.\n"
                u8"\n"
-               u8"    ExpectedScriptHash: SHA256 hash of the install script, in hex.\n"
+               u8"    ExpectedScriptHash: SHA256 hash of the install script (encoded as UTF8), in hex.\n"
                u8"\n"
                u8"    OptionalArgs: optional arguments to pass along to the script.\n"
                u8"\n"

--- a/main.cpp
+++ b/main.cpp
@@ -43,7 +43,6 @@ inline wchar_t* SkipUntilNotWhitespace( wchar_t* str )
 // EXE.
 inline wchar_t* FindTheRestOfTheCommandLine()
 {
-    wchar_t* returnMe = NULL;
     wchar_t* str = GetCommandLine();
 
     if( str[ 0 ] == L'"' )
@@ -102,7 +101,7 @@ int MyStrCmpI( const wchar_t* s1, const wchar_t* s2 )
         DWORD dwErr = GetLastError();
         Print( L"Something went wrong.");
         ExitProcess(dwErr);
-        return 0; // unreachable
+        //return 0; // unreachable
     }
 
     // From CompareStringOrdinal documentation: "the value 2 can be subtracted
@@ -115,39 +114,6 @@ int main() // no C runtime, so no args here
 {
     g_hStdOut = GetStdHandle( STD_OUTPUT_HANDLE );
     Print( L"Well hello there.\n" );
-
-    wchar_t newCmdLine[ 16384 ];
-    wchar_t* dst = newCmdLine;
-    const wchar_t* pastEnd = &newCmdLine[ _countof( newCmdLine ) ];
-
-    const wchar_t cmdFrag0[] = L"-NoProfile -ExecutionPolicy RemoteSigned -Command $env:PSModulePath = $null ; "
-                               L"try { "
-                                   L"$outerArgs = $args ; "
-                                   L"$theScript = (iwr ";
-
-    const wchar_t cmdFrag1[] =     L"$env:_POWERSHELL_STUB_TEST_URL_SUFFIX -UseBasic -EA Stop).Content ; "
-                                   L"$bytes = [System.Text.Encoding]::Unicode.GetBytes( $theScript ) ; "
-                                   L"$hash = ([Security.Cryptography.SHA256]::Create().ComputeHash( $bytes ) | %{ $_.ToString('x2') }) -join '' ; "
-                                   L"$expectedHash = '";
-
-    const wchar_t cmdFrag2[] =     L"' ; "
-                                   L"if( $hash -ne $expectedHash ) "
-                                   L"{ "
-                                       L"throw \"Hash mismatch: expected $expectedHash but got $hash\" "
-                                   L"} ; "
-                                   L"$sig = Get-AuthenticodeSignature -Source 'theScript.ps1' -Content $bytes ; "
-                                   L"if( ($sig.Status -ne 'Valid') -and ($sig.Status -ne 'NotSigned') ) "
-                                   L"{ "
-                                       L"throw \"Signature error: $($sig.Status)\" "
-                                   L"} ; "
-                                   L"Invoke-Expression \\\". { $theScript } -I  @outerArgs -EA Stop\\\" ; "
-                               L"} catch { ";
-
-    const wchar_t c_Silent[] = L"Silent";
-    const wchar_t c_SilentWithProgress[] = L"SilentWithProgress";
-    const wchar_t c_Interactive[] = L"Interactive";
-
-    dst = CopyStr( dst, L"", pastEnd );
 
     wchar_t* commandLineArgs = FindTheRestOfTheCommandLine();
 
@@ -166,8 +132,7 @@ int main() // no C runtime, so no args here
     if( !*cursor ) \
     { \
         Print( L"Expected more on the command line." ); \
-        ExitProcess( -1 ); \
-        return -1; \
+        ExitProcess( (UINT) -1 ); \
     } \
 
     EXPECT_MORE_CMDLINE
@@ -215,6 +180,10 @@ int main() // no C runtime, so no args here
     Print( expectedScriptHash );
     Print( L"\n" );
 
+    const wchar_t c_Silent[] = L"Silent";
+    const wchar_t c_SilentWithProgress[] = L"SilentWithProgress";
+    const wchar_t c_Interactive[] = L"Interactive";
+
     bool bIsSilent = 0 == MyStrCmpI( installMode, c_Silent );
     bool bIsSilentWithProgress = 0 == MyStrCmpI( installMode, c_SilentWithProgress );
     bool bIsInteractive = 0 == MyStrCmpI( installMode, c_Interactive );
@@ -224,8 +193,8 @@ int main() // no C runtime, so no args here
         Print( L"Install mode must be one of Silent, SilentWithProgress, or Interactive. Not '" );
         Print( installMode );
         Print( L"'.\n" );
-        ExitProcess( -1 );
-        return -1;
+        ExitProcess( (UINT) - 1);
+        //return -1;
     }
 
     if( bIsSilent )
@@ -243,54 +212,93 @@ int main() // no C runtime, so no args here
         Print( L"Interactive mode.\n" );
     }
 
+    wchar_t newCmdLine[ 4096 ];
+    wchar_t* dst = newCmdLine;
+    const wchar_t* pastEnd = &newCmdLine[ _countof( newCmdLine ) ];
+
+    const wchar_t cmdFrag0[] = L"-NoProfile -ExecutionPolicy RemoteSigned -Command $env:PSModulePath = $null ; "
+                               L"try { "
+                                   L"$outerArgs = $args ; "
+                                   L"$theScript = (iwr ";
+
+    const wchar_t cmdFrag1[] =     L"$env:_POWERSHELL_STUB_TEST_URL_SUFFIX -UseBasic -EA Stop).Content ; "
+                                   L"$bytes = [System.Text.Encoding]::Unicode.GetBytes( $theScript ) ; "
+                                   L"$hash = ([Security.Cryptography.SHA256]::Create().ComputeHash( $bytes ) | %{ $_.ToString('x2') }) -join '' ; "
+                                   L"$expectedHash = '";
+
+    const wchar_t cmdFrag2[] =     L"' ; "
+                                   L"if( $hash -ne $expectedHash ) "
+                                   L"{ "
+                                       L"throw \"Hash mismatch: expected $expectedHash but got $hash\" "
+                                   L"} ; "
+                                   L"$sig = Get-AuthenticodeSignature -Source 'theScript.ps1' -Content $bytes ; "
+                                   L"if( ($sig.Status -ne 'Valid') -and ($sig.Status -ne 'NotSigned') ) "
+                                   L"{ "
+                                       L"throw \"Signature error: $($sig.Status)\" "
+                                   L"} ; "
+                                   L"Invoke-Expression \\\". { $theScript } -I  @outerArgs -EA Stop\\\" ; "
+                               L"} catch { ";
+
+
+    dst = CopyStr( dst, cmdFrag0, pastEnd );
+    dst = CopyStr( dst, scriptUrl, pastEnd );
+    dst = CopyStr( dst, cmdFrag1, pastEnd );
+    dst = CopyStr( dst, expectedScriptHash, pastEnd );
+    dst = CopyStr( dst, cmdFrag2, pastEnd );
+
+    Print( L"\n\nNew command: " );
+    Print( newCmdLine );
+
+
+
     ExitProcess( 0 );
-    return 0;
+ // return 0;
 
-    PROCESS_INFORMATION pi = { };
-    STARTUPINFOW si;
-    SecureZeroMemory( &si, sizeof( si ) ); // compiler complained about no memset; whatevs
-    si.cb = (DWORD) sizeof( si );
+ // PROCESS_INFORMATION pi = { };
+ // STARTUPINFOW si;
+ // SecureZeroMemory( &si, sizeof( si ) ); // compiler complained about no memset; whatevs
+ // si.cb = (DWORD) sizeof( si );
 
-    const wchar_t* wszPowershellExe = L"C:\\Windows\\system32\\WindowsPowerShell\\v1.0\\powershell.exe";
+ // const wchar_t* wszPowershellExe = L"C:\\Windows\\system32\\WindowsPowerShell\\v1.0\\powershell.exe";
 
-    BOOL bItWorked = CreateProcessW( wszPowershellExe,
-                                     commandLineArgs,
-                                     nullptr,   // lpProcessAttributes
-                                     nullptr,   // lpThreadAttributes
-                                     TRUE,      // bInheritHandles
-                                     0,         // dwFlags
-                                     nullptr,   // lpEnvironment
-                                     nullptr,   // lpCurrentDirectory
-                                     &si,
-                                     &pi );
+ // BOOL bItWorked = CreateProcessW( wszPowershellExe,
+ //                                  commandLineArgs,
+ //                                  nullptr,   // lpProcessAttributes
+ //                                  nullptr,   // lpThreadAttributes
+ //                                  TRUE,      // bInheritHandles
+ //                                  0,         // dwFlags
+ //                                  nullptr,   // lpEnvironment
+ //                                  nullptr,   // lpCurrentDirectory
+ //                                  &si,
+ //                                  &pi );
 
-    if( !bItWorked )
-    {
-        ExitProcess( GetLastError() );
-        return -1; // unreachable
-    }
+ // if( !bItWorked )
+ // {
+ //     ExitProcess( GetLastError() );
+ //     //return -1; // unreachable
+ // }
 
-    // Ignoring result...
-    WaitForSingleObject( pi.hProcess, INFINITE );
+ // // Ignoring result...
+ // WaitForSingleObject( pi.hProcess, INFINITE );
 
-    DWORD dwRet = 0;
-    bItWorked = GetExitCodeProcess( pi.hProcess, &dwRet );
+ // DWORD dwRet = 0;
+ // bItWorked = GetExitCodeProcess( pi.hProcess, &dwRet );
 
-    CloseHandle( pi.hProcess );
-    CloseHandle( pi.hThread );
+ // CloseHandle( pi.hProcess );
+ // CloseHandle( pi.hThread );
 
-    if( !bItWorked )
-    {
-        ExitProcess( GetLastError() );
-        return -1; // unreachable
-    }
+ // if( !bItWorked )
+ // {
+ //     ExitProcess( GetLastError() );
+ //     //return -1; // unreachable
+ // }
 
-    // Note that we use ExitProcess to end execution instead of just "return dwRet",
-    // because returning from main leads to running RtlExitUserThread, and when running on
-    // an ARM64 machine, that was failing in a bizarre way (it appeared that the return
-    // code was not being propagated--one speculation was that it might be returning the
-    // thread's exit code instead of main's--and when running under a debugger to
-    // investigate, the debugger would get stuck and you couldn't break in).
-    ExitProcess( dwRet );
-    return -1; // unreachable
+ // // Note that we use ExitProcess to end execution instead of just "return dwRet",
+ // // because returning from main leads to running RtlExitUserThread, and when running on
+ // // an ARM64 machine, that was failing in a bizarre way (it appeared that the return
+ // // code was not being propagated--one speculation was that it might be returning the
+ // // thread's exit code instead of main's--and when running under a debugger to
+ // // investigate, the debugger would get stuck and you couldn't break in).
+ // ExitProcess( dwRet );
+    //return -1; // unreachable
 }

--- a/main.cpp
+++ b/main.cpp
@@ -97,23 +97,45 @@ int MyStrCmpI( const char8_t* s1, const char8_t* s2 )
     return lstrcmpiA( (const char*) s1, (const char*) s2 );
 }
 
+bool _HandleUsageRequest( const char8_t* installMode )
+{
+    const char8_t c_Help1[] = u8"help";
+    const char8_t c_Help2[] = u8"/?";
+    const char8_t c_Help3[] = u8"-?";
+
+    if( (0 == MyStrCmpI( installMode, c_Help1 )) ||
+        (0 == MyStrCmpI( installMode, c_Help2 )) ||
+        (0 == MyStrCmpI( installMode, c_Help3 )) )
+    {
+        Print( u8"\nUsage: PowershellStub.exe [WhatIf] <InstallMode> <ScriptURL> <ExpectedScriptHash> [<OptionalArgs>]\n"
+               u8"\n"
+               u8"This program is intended to be used as an \"installer\" EXE for winget, where the actual\n"
+               u8"install logic is implemented in a downloadable PowerShell script. It launches powershell.exe\n"
+               u8"with a command line that downloads the script, verifies its hash, verifies its signature\n"
+               u8"(if any) and then runs it.\n"
+               u8"\n"
+               u8"  WhatIf: (optional) if specified, just prints the command line that would be used.\n"
+               u8"\n"
+               u8"  InstallMode: one of Interactive, Silent, or SilentWithProgress.\n"
+               u8"\n"
+               u8"  ScriptURL: URL from which to download the PowerShell script to run.\n"
+               u8"\n"
+               u8"  ExpectedScriptHash: SHA256 hash of the script, in hex.\n"
+               u8"\n"
+               u8"  OptionalArgs: optional arguments to pass along to the script.\n\n"
+             );
+        return true;
+    }
+    return false;
+} // end _HandleUsageRequest()
+
 int main() // no C runtime, so no args here
 {
     SetConsoleCP(CP_UTF8);
     SetConsoleOutputCP(CP_UTF8);
     g_hStdOut = GetStdHandle( STD_OUTPUT_HANDLE );
- // Print( "Well hello there.\n" );
 
     char8_t* commandLineArgs = FindTheRestOfTheCommandLine();
-
-    // Expected arguments:
-    //
-    //  1. InstallMode: one of Interactive, Silent, or SilentWithProgress.
-    //  2. Script URL.
-    //  3. Expected script hash.
-    //
-    // Additional arguments are optional and will be passed along to the script.
-    //
 
     char8_t* cursor = commandLineArgs;
 
@@ -135,11 +157,39 @@ int main() // no C runtime, so no args here
 
     char8_t* installMode = cursor;
 
+    if( _HandleUsageRequest( installMode ) )
+    {
+        ExitProcess( (UINT) -2 );
+    }
+
+    bool whatIf = false;
+
     cursor = SkipUntilWhitespace( cursor );
 
     EXPECT_MORE_CMDLINE
 
     *cursor++ = '\0';
+
+    if( 0 == MyStrCmpI( installMode, u8"WhatIf" ) )
+    {
+        whatIf = true;
+
+        cursor = SkipUntilNotWhitespace( cursor );
+
+        EXPECT_MORE_CMDLINE
+
+        installMode = cursor;
+
+        cursor = SkipUntilWhitespace( cursor );
+
+        EXPECT_MORE_CMDLINE
+
+        *cursor++ = '\0';
+        cursor = SkipUntilNotWhitespace( cursor );
+
+        EXPECT_MORE_CMDLINE
+    }
+
     cursor = SkipUntilNotWhitespace( cursor );
 
     char8_t* scriptUrl = cursor;
@@ -164,18 +214,6 @@ int main() // no C runtime, so no args here
 
     char8_t* optionalArgs = cursor;
 
-//  Print( u8"Install mode: " );
-//  Print( installMode );
-//  Print( u8"\n" );
-
-//  Print( u8"Script URL: " );
-//  Print( scriptUrl );
-//  Print( u8"\n" );
-
-//  Print( u8"Expected script hash: " );
-//  Print( expectedScriptHash );
-//  Print( u8"\n" );
-
     const char8_t c_Silent[] = u8"Silent";
     const char8_t c_SilentWithProgress[] = u8"SilentWithProgress";
     const char8_t c_Interactive[] = u8"Interactive";
@@ -189,30 +227,15 @@ int main() // no C runtime, so no args here
         Print( u8"Install mode must be one of Silent, SilentWithProgress, or Interactive. Not '" );
         Print( installMode );
         Print( u8"'.\n" );
-        ExitProcess( (UINT) - 1);
-        //return -1;
+        ExitProcess( (UINT) -3 );
     }
-
-//  if( bIsSilent )
-//  {
-//      Print( u8"Silent mode.\n" );
-//  }
-
-//  if( bIsSilentWithProgress )
-//  {
-//      Print( u8"SilentWithProgress mode.\n" );
-//  }
-
-//  if( bIsInteractive )
-//  {
-//      Print( u8"Interactive mode.\n" );
-//  }
 
     char8_t newCmdLine[ 4096 ];
     char8_t* dst = newCmdLine;
     const char8_t* pastEnd = &newCmdLine[ _countof( newCmdLine ) ];
 
     const char8_t cmdFrag0[] = u8" -NoProfile -ExecutionPolicy RemoteSigned -Command $env:PSModulePath = $null ; "
+                               u8"Set-StrictMode -Version Latest ; "
                                u8"try { "
                                    u8"$theScript = (iwr ";
 
@@ -238,9 +261,9 @@ int main() // no C runtime, so no args here
 
     const char8_t cmdFrag4_Interactive[] =
                                    u8"Write-Host $_ -Fore Red ; "
-                                   u8"$rsp = Read-Host 'pausing... [enter] to finish' ; "
+                                   u8"$rsp = Read-Host 'pausing... press [enter] to finish' ; "
                                    u8"if( $rsp -eq 'd' ) { $host.EnterNestedPrompt() } ; "
-                                   u8"throw"
+                                   u8"throw "
                                u8"}";
 
     const char8_t cmdFrag4_Silent[] =
@@ -268,13 +291,23 @@ int main() // no C runtime, so no args here
         dst = CopyStr( dst, cmdFrag4_Silent, pastEnd );
     }
 
- // Print( u8"\nCommandline: " );
- // Print( newCmdLine );
- // Print( u8"\n\n" );
+    if( whatIf )
+    {
+        Print( u8"\nWould run powershell.exe with command line:\n\n   " );
+        Print( newCmdLine );
+        Print( u8"\n\n" );
+        ExitProcess( (UINT) -4 );
+    }
+
+    if( dst == (pastEnd - 1) )
+    {
+        Print( u8"Command line too long. Use WhatIf to see it.\n" );
+        ExitProcess( (UINT) -5 );
+    }
 
     PROCESS_INFORMATION pi = { };
     STARTUPINFOA si;
-    SecureZeroMemory( &si, sizeof( si ) ); // compiler complained about no memset; whatevs
+    SecureZeroMemory( &si, sizeof( si ) );
     si.cb = (DWORD) sizeof( si );
 
     const char* szPowershellExe = "C:\\Windows\\system32\\WindowsPowerShell\\v1.0\\powershell.exe";

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,6 @@
 //
-// PowershellStub: a very small EXE that just launches Windows PowerShell (passing
-// arguments along).
+// PowershellStub: a very small EXE that launches Windows PowerShell to download, verify,
+// and run a script.
 //
 
 #include <Windows.h>
@@ -38,7 +38,6 @@ inline char8_t* SkipUntilNotWhitespace( char8_t* str )
     return str;
 } // end SkipUntilNotWhitespace()
 
-
 // Returns a pointer to the part of the current process command line immediately after the
 // EXE.
 inline char8_t* FindTheRestOfTheCommandLine()
@@ -70,13 +69,9 @@ inline char8_t* CopyStr( char8_t* dest, const char8_t* src, const char8_t* pastD
     return dest;
 } // end CopyStr()
 
-HANDLE g_hStdOut = 0;
-
 #define _countof(_Array) ((sizeof(_Array) / sizeof(_Array[0])))
 
-// TODO: does this really evaluate at compile-time, or do I need to switch to a recursive
-// method?
-constexpr DWORD MyWcslen( const char8_t* s )
+constexpr DWORD MyStrLen( const char8_t* s )
 {
     DWORD cch = 0;
     while( *s )
@@ -85,12 +80,14 @@ constexpr DWORD MyWcslen( const char8_t* s )
         s++;
     }
     return cch;
-}
+} // end MyStrLen()
+
+HANDLE g_hStdOut = 0;
 
 void Print( const char8_t* s )
 {
-    WriteConsoleA( g_hStdOut, s, MyWcslen( s ), nullptr, nullptr );
-} // end Print()
+    WriteConsoleA( g_hStdOut, s, MyStrLen( s ), nullptr, nullptr );
+}
 
 int MyStrCmpI( const char8_t* s1, const char8_t* s2 )
 {
@@ -107,30 +104,139 @@ bool _HandleUsageRequest( const char8_t* installMode )
         (0 == MyStrCmpI( installMode, c_Help2 )) ||
         (0 == MyStrCmpI( installMode, c_Help3 )) )
     {
-        Print( u8"\nUsage: PowershellStub.exe [WhatIf] <InstallMode> <ScriptURL> <ExpectedScriptHash> [<OptionalArgs>]\n"
+        Print( u8"\nUsage: PowershellStub.exe [WhatIf|WhatIfRaw] <InstallMode> <ScriptURL> <ExpectedScriptHash> [<OptionalArgs>]\n"
                u8"\n"
-               u8"This program is intended to be used as an \"installer\" EXE for winget, where the actual\n"
-               u8"install logic is implemented in a downloadable PowerShell script. It launches powershell.exe\n"
-               u8"with a command line that downloads the script, verifies its hash, verifies its signature\n"
-               u8"(if any) and then runs it.\n"
+               u8"This program is intended to be used as an \"installer\" EXE for winget, where the actual install logic is\n"
+               u8"implemented in a downloadable PowerShell script. It launches powershell.exe with a command line that contains\n"
+               u8"a wrapper script, which downloads the install script, verifies its hash, verifies its signature (if any), and\n"
+               u8"then runs it.\n"
                u8"\n"
-               u8"  WhatIf: (optional) if specified, just prints the command line that would be used.\n"
+               u8"    WhatIf | WhatIfRaw: (optional) if specified, just prints the command line that would be used.\n"
                u8"\n"
-               u8"  InstallMode: one of Interactive, Silent, or SilentWithProgress.\n"
+               u8"    InstallMode: one of Interactive, Silent, or SilentWithProgress.\n"
                u8"\n"
-               u8"  ScriptURL: URL from which to download the PowerShell script to run.\n"
+               u8"    ScriptURL: URL from which to download the PowerShell script to run.\n"
                u8"\n"
-               u8"  ExpectedScriptHash: SHA256 hash of the script, in hex.\n"
+               u8"    ExpectedScriptHash: SHA256 hash of the install script, in hex.\n"
                u8"\n"
-               u8"  OptionalArgs: optional arguments to pass along to the script.\n\n"
+               u8"    OptionalArgs: optional arguments to pass along to the script.\n"
+               u8"\n"
+               u8"Details about how the install script is executed (use WhatIf to see the wrapper script):\n"
+               u8"\n"
+               u8"The script is executed with StrictMode on, RemoteSigned execution policy, and -NoProfile.\n"
+               u8"\n"
+               u8"The value of the environment variable $env:_POWERSHELL_STUB_TEST_URL_SUFFIX is appended to the ScriptUrl.\n"
+               u8"This is handy for testing a new version of the install script without having to update the winget package.\n"
+               u8"\n"
+               u8"The winget install mode is passed as a switch parameter to the script (e.g. -Silent), followed by the optional\n"
+               u8"parameters, followed by -EA Stop (all errors are treated as terminating errors).\n"
+               u8"\n"
+               u8"The downloaded install script does not have to be signed, but if it is, the signature must be valid.\n"
+               u8"\n"
+               u8"If an error occurs in Interactive mode, the wrapper script pauses so you can read the error. If you enter 'd'\n"
+               u8"at the prompt, you'll enter a nested shell so you can poke around more (run 'exit' to quit the nested shell).\n"
+               u8"\n"
+               u8"PowerShellStub.exe returns the return code of the powershell.exe process. The exit code for an uncaught\n"
+               u8"exception is 1.\n"
+               u8"\n"
              );
         return true;
     }
     return false;
 } // end _HandleUsageRequest()
 
+bool StartsWith( const char8_t* str, const char8_t* prefix )
+{
+    while( *prefix )
+    {
+        if( *str != *prefix )
+        {
+            return false;
+        }
+        str++;
+        prefix++;
+    }
+    return true;
+} // end StartsWith()
+
+// This is an EXTREMELY basic algorithm for printing out the PowerShell script in a
+// somewhat readable way.
+//
+// N.B. Getting good results depends on careful use of whitespace in the script!
+//
+// If an opening brace is surrounded by space, or a closing brace is preceded by a space,
+// that's the signal that we want the brace on its own line; else it's left alone (for
+// ScriptBlocks).
+//
+// Semicolons are turned into newlines.
+//
+// The command line escaping for double quotes is removed.
+void PrettyPrint( char8_t* s )
+{
+    int indent = 4;
+
+    auto printIndent = [&]() {
+        for( int i = 0; i < indent; i++ )
+        {
+            Print( u8" " );
+        }
+    };
+
+    auto skipSpaces = [&]() {
+        while( *s == ' ' )
+        {
+            s++;
+        }
+    };
+
+    while( *s )
+    {
+        if( *s == ';' )
+        {
+            Print( u8"\n" );
+            printIndent();
+            s += 1;
+            skipSpaces();
+        }
+        else if( StartsWith( s, u8" { " ) )
+        {
+            Print( u8"\n" );
+            printIndent();
+            Print( u8"{\n" );
+            indent += 4;
+            printIndent();
+            s += 3;
+            skipSpaces();
+        }
+        else if( StartsWith( s, u8" }" ) )
+        {
+            Print( u8"\n" );
+            indent -= 4;
+            printIndent();
+            Print( u8"}\n" );
+            printIndent();
+            s += 2;
+            skipSpaces();
+        }
+        else if( StartsWith( s, u8"\\\"" ) )
+        {
+            Print( u8"\"" );
+            s += 2;
+        }
+        else
+        {
+            char8_t buf[ 2 ] = { *s, 0 };
+            Print( buf );
+            s++;
+        }
+    }
+} // end PrettyPrint()
+
 int main() // no C runtime, so no args here
 {
+    // I found that I could significantly shrink the program by switching from Unicode
+    // (wchar_t everywhere) to UTF8 (because that halved the size of all the string
+    // constants).
     SetConsoleCP(CP_UTF8);
     SetConsoleOutputCP(CP_UTF8);
     g_hStdOut = GetStdHandle( STD_OUTPUT_HANDLE );
@@ -163,6 +269,7 @@ int main() // no C runtime, so no args here
     }
 
     bool whatIf = false;
+    bool whatIfRaw = false;
 
     cursor = SkipUntilWhitespace( cursor );
 
@@ -173,7 +280,14 @@ int main() // no C runtime, so no args here
     if( 0 == MyStrCmpI( installMode, u8"WhatIf" ) )
     {
         whatIf = true;
+    }
+    else if( 0 == MyStrCmpI( installMode, u8"WhatIfRaw" ) )
+    {
+        whatIfRaw = true;
+    }
 
+    if( whatIf || whatIfRaw )
+    {
         cursor = SkipUntilNotWhitespace( cursor );
 
         EXPECT_MORE_CMDLINE
@@ -214,13 +328,13 @@ int main() // no C runtime, so no args here
 
     char8_t* optionalArgs = cursor;
 
-    const char8_t c_Silent[] = u8"Silent";
-    const char8_t c_SilentWithProgress[] = u8"SilentWithProgress";
-    const char8_t c_Interactive[] = u8"Interactive";
+    const char8_t c_Silent[]                = u8"Silent";
+    const char8_t c_SilentWithProgress[]    = u8"SilentWithProgress";
+    const char8_t c_Interactive[]           = u8"Interactive";
 
-    bool bIsSilent = 0 == MyStrCmpI( installMode, c_Silent );
-    bool bIsSilentWithProgress = 0 == MyStrCmpI( installMode, c_SilentWithProgress );
-    bool bIsInteractive = 0 == MyStrCmpI( installMode, c_Interactive );
+    bool bIsSilent              = 0 == MyStrCmpI( installMode, c_Silent );
+    bool bIsSilentWithProgress  = 0 == MyStrCmpI( installMode, c_SilentWithProgress );
+    bool bIsInteractive         = 0 == MyStrCmpI( installMode, c_Interactive );
 
     if( !bIsSilent && !bIsSilentWithProgress && !bIsInteractive )
     {
@@ -234,14 +348,26 @@ int main() // no C runtime, so no args here
     char8_t* dst = newCmdLine;
     const char8_t* pastEnd = &newCmdLine[ _countof( newCmdLine ) ];
 
+    // N.B. Getting decent results from the PrettyPrint function depends on careful use of
+    // spaces around braces!
+    //
+    // If an opening brace is surrounded by space, or a closing brace is preceded by a
+    // space, that's the signal to the PrettyPrint function that we want the brace on its
+    // own line; else it's left alone (because it's a ScriptBlock)."
+
+    // Setting $env:PSModulePath to null forces a (machine-) default PSModulePath, which
+    // can be important to avoid "The PSModulePath Problem":
+    // https://github.com/PowerShell/PowerShell/issues/18108#issuecomment-2269703022
     const char8_t cmdFrag0[] = u8" -NoProfile -ExecutionPolicy RemoteSigned -Command $env:PSModulePath = $null ; "
                                u8"Set-StrictMode -Version Latest ; "
                                u8"try { "
                                    u8"$theScript = (iwr ";
 
+    // The utility of the environment variable here is to allow you to test a new version
+    // of your install script, without needing to touch your winget manifest.
     const char8_t cmdFrag1[] =     u8"$env:_POWERSHELL_STUB_TEST_URL_SUFFIX -UseBasic -EA Stop).Content ; "
                                    u8"$bytes = [System.Text.Encoding]::Unicode.GetBytes( $theScript ) ; "
-                                   u8"$hash = ([Security.Cryptography.SHA256]::Create().ComputeHash( $bytes ) | %{ $_.ToString('x2') }) -join '' ; "
+                                   u8"$hash = ([Security.Cryptography.SHA256]::Create().ComputeHash( $bytes ) | %{$_.ToString('x2')}) -join '' ; "
                                    u8"$expectedHash = '";
 
     const char8_t cmdFrag2[] =     u8"' ; "
@@ -254,9 +380,9 @@ int main() // no C runtime, so no args here
                                    u8"{ "
                                        u8"throw \\\"Signature error: $($sig.Status)\\\" "
                                    u8"} ; "
-                                   u8"Invoke-Expression \\\". { $theScript } -";
+                                   u8"Invoke-Expression \\\". {$theScript} -";
 
-    const char8_t cmdFrag3[] =     u8" -EA Stop\\\" ; "
+    const char8_t cmdFrag3[] =     u8" -EA Stop\\\" "
                                u8"} catch { ";
 
     const char8_t cmdFrag4_Interactive[] =
@@ -269,8 +395,13 @@ int main() // no C runtime, so no args here
     const char8_t cmdFrag4_Silent[] =
                                    u8"Write-Host $_ -Fore Red ; "
                                    u8"Start-Sleep -Seconds 5 ; " // Give people a chance to at least see the error.
-                                   u8"throw"
+                                   u8"throw "
                                u8"}";
+
+    if( !bIsInteractive )
+    {
+        dst = CopyStr( dst, u8" -NonInteractive", pastEnd );
+    }
 
     dst = CopyStr( dst, cmdFrag0, pastEnd );
     dst = CopyStr( dst, scriptUrl, pastEnd );
@@ -293,7 +424,15 @@ int main() // no C runtime, so no args here
 
     if( whatIf )
     {
-        Print( u8"\nWould run powershell.exe with command line:\n\n   " );
+        Print( u8"\nWould run powershell.exe with a command line to run the following code:\n" );
+        Print( u8"(use 'WhatIfRaw' instead to see the unmodified command line arguments)\n\n   " );
+        PrettyPrint( newCmdLine );
+        Print( u8"\n\n" );
+        ExitProcess( (UINT) -4 );
+    }
+    else if( whatIfRaw )
+    {
+        Print( u8"\nWould run powershell.exe with the following command line:\n\n   " );
         Print( newCmdLine );
         Print( u8"\n\n" );
         ExitProcess( (UINT) -4 );
@@ -301,11 +440,11 @@ int main() // no C runtime, so no args here
 
     if( dst == (pastEnd - 1) )
     {
-        Print( u8"Command line too long. Use WhatIf to see it.\n" );
+        Print( u8"Command line too long. Use WhatIf (or WhatIfRaw) to see it.\n" );
         ExitProcess( (UINT) -5 );
     }
 
-    PROCESS_INFORMATION pi = { };
+    PROCESS_INFORMATION pi = { 0 };
     STARTUPINFOA si;
     SecureZeroMemory( &si, sizeof( si ) );
     si.cb = (DWORD) sizeof( si );
@@ -325,6 +464,7 @@ int main() // no C runtime, so no args here
 
     if( !bItWorked )
     {
+        Print( u8"CreateProcess failed.\n" );
         ExitProcess( GetLastError() );
     }
 
@@ -339,6 +479,7 @@ int main() // no C runtime, so no args here
 
     if( !bItWorked )
     {
+        Print( u8"GetExitCodeProcess failed.\n" );
         ExitProcess( GetLastError() );
     }
 

--- a/main.cpp
+++ b/main.cpp
@@ -253,7 +253,7 @@ int main() // no C runtime, so no args here
 #define EXPECT_MORE_CMDLINE \
     if( !*cursor ) \
     { \
-        Print( u8"Expected more on the command line." ); \
+        Print( u8"Expected more on the command line.\n" ); \
         ExitProcess( (UINT) -1 ); \
     } \
 
@@ -358,7 +358,7 @@ int main() // no C runtime, so no args here
     //
     // If an opening brace is surrounded by space, or a closing brace is preceded by a
     // space, that's the signal to the PrettyPrint function that we want the brace on its
-    // own line; else it's left alone (because it's a ScriptBlock)."
+    // own line; else it's left alone (because it's a ScriptBlock).
 
     // Setting $env:PSModulePath to null forces a (machine-) default PSModulePath, which
     // can be important to avoid "The PSModulePath Problem":

--- a/main.cpp
+++ b/main.cpp
@@ -27,6 +27,18 @@ inline wchar_t* SkipUntilWhitespace( wchar_t* str )
     return str;
 } // end SkipUntilWhitespace()
 
+inline wchar_t* SkipUntilNotWhitespace( wchar_t* str )
+{
+    while( *str &&
+           ((*str == ' ') || (*str == '\t')) )
+    {
+        str++;
+    }
+
+    return str;
+} // end SkipUntilNotWhitespace()
+
+
 // Returns a pointer to the part of the current process command line immediately after the
 // EXE.
 inline wchar_t* FindTheRestOfTheCommandLine()
@@ -44,11 +56,143 @@ inline wchar_t* FindTheRestOfTheCommandLine()
     }
 
     return str;
-} // end GetFirstArg()
+} // end FindTheRestOfTheCommandLine()
+
+inline wchar_t* CopyStr( wchar_t* dest, const wchar_t* src, const wchar_t* pastDestEnd )
+{
+    // The -1 is to leave room for the terminating null.
+    while( (dest < (pastDestEnd - 1)) && *src )
+    {
+        *dest = *src;
+        dest++;
+        src++;
+    }
+    *dest = 0;
+    return dest;
+} // end CopyStr()
+
+HANDLE g_hStdOut = 0;
+
+#define _countof(_Array) ((sizeof(_Array) / sizeof(_Array[0])))
+
+DWORD MyWcslen( const wchar_t* s )
+{
+    DWORD cch = 0;
+    while( *s )
+    {
+        cch++;
+        s++;
+    }
+    return cch;
+}
+
+void Print( const wchar_t* s )
+{
+    WriteConsoleW( g_hStdOut, s, MyWcslen( s ), nullptr, nullptr );
+} // end Print()
 
 int main() // no C runtime, so no args here
 {
+    g_hStdOut = GetStdHandle( STD_OUTPUT_HANDLE );
+    Print( L"Well hello there.\n" );
+
+    wchar_t newCmdLine[ 16384 ];
+    wchar_t* dst = newCmdLine;
+    const wchar_t* pastEnd = &newCmdLine[ _countof( newCmdLine ) ];
+
+    const wchar_t cmdFrag0[] = L"-NoProfile -ExecutionPolicy RemoteSigned -Command $env:PSModulePath = $null ; "
+                               L"try { "
+                                   L"$outerArgs = $args ; "
+                                   L"$theScript = (iwr ";
+
+    const wchar_t cmdFrag1[] =     L"$env:_POWERSHELL_STUB_TEST_URL_SUFFIX -UseBasic -EA Stop).Content ; "
+                                   L"$bytes = [System.Text.Encoding]::Unicode.GetBytes( $theScript ) ; "
+                                   L"$hash = ([Security.Cryptography.SHA256]::Create().ComputeHash( $bytes ) | %{ $_.ToString('x2') }) -join '' ; "
+                                   L"$expectedHash = '";
+
+    const wchar_t cmdFrag2[] =     L"' ; "
+                                   L"if( $hash -ne $expectedHash ) "
+                                   L"{ "
+                                       L"throw \"Hash mismatch: expected $expectedHash but got $hash\" "
+                                   L"} ; "
+                                   L"$sig = Get-AuthenticodeSignature -Source 'theScript.ps1' -Content $bytes ; "
+                                   L"if( ($sig.Status -ne 'Valid') -and ($sig.Status -ne 'NotSigned') ) "
+                                   L"{ "
+                                       L"throw \"Signature error: $($sig.Status)\" "
+                                   L"} ; "
+                                   L"Invoke-Expression \\\". { $theScript } -I  @outerArgs -EA Stop\\\" ; "
+                               L"} catch { ";
+
+    dst = CopyStr( dst, L"", pastEnd );
+
     wchar_t* commandLineArgs = FindTheRestOfTheCommandLine();
+
+    // Expected arguments:
+    //
+    //  1. InstallMode: one of Interactive, Silent, or SilentWithProgress.
+    //  2. Script URL.
+    //  3. Expected script hash.
+    //
+    // TODO: extra args
+    //
+
+    wchar_t* cursor = commandLineArgs;
+
+#define EXPECT_MORE_CMDLINE \
+    if( !*cursor ) \
+    { \
+        Print( L"Expected more on the command line." ); \
+        ExitProcess( -1 ); \
+        return -1; \
+    } \
+
+    EXPECT_MORE_CMDLINE
+
+    cursor = SkipUntilWhitespace( cursor );
+
+    EXPECT_MORE_CMDLINE
+
+    *cursor++ = L'\0';
+    cursor = SkipUntilNotWhitespace( cursor );
+
+    wchar_t* installMode = cursor;
+
+    cursor = SkipUntilWhitespace( cursor );
+
+    EXPECT_MORE_CMDLINE
+
+    *cursor++ = L'\0';
+    cursor = SkipUntilNotWhitespace( cursor );
+
+    wchar_t* scriptUrl = cursor;
+
+    cursor = SkipUntilWhitespace( cursor );
+
+    EXPECT_MORE_CMDLINE
+
+    *cursor++ = L'\0';
+    cursor = SkipUntilNotWhitespace( cursor );
+
+    wchar_t* expectedScriptHash = cursor;
+
+    // TODO: optional/extra args
+
+
+
+    Print( L"Install mode: " );
+    Print( installMode );
+    Print( L"\n" );
+
+    Print( L"Script URL: " );
+    Print( scriptUrl );
+    Print( L"\n" );
+
+    Print( L"Expected script hash: " );
+    Print( expectedScriptHash );
+    Print( L"\n" );
+
+    ExitProcess( 0 );
+    return 0;
 
     PROCESS_INFORMATION pi = { };
     STARTUPINFOW si;

--- a/main.cpp
+++ b/main.cpp
@@ -371,7 +371,7 @@ int main() // no C runtime, so no args here
     // The utility of the environment variable here is to allow you to test a new version
     // of your install script, without needing to touch your winget manifest.
     const char8_t cmdFrag1[] =     u8"$env:_POWERSHELL_STUB_TEST_URL_SUFFIX -UseBasic -EA Stop).Content ; "
-                                   u8"$bytes = [System.Text.Encoding]::Unicode.GetBytes( $theScript ) ; "
+                                   u8"$bytes = [System.Text.Encoding]::UTF8.GetBytes( $theScript ) ; "
                                    u8"$hash = ([Security.Cryptography.SHA256]::Create().ComputeHash( $bytes ) | %{$_.ToString('x2')}) -join '' ; "
                                    u8"$expectedHash = '";
 

--- a/main.cpp
+++ b/main.cpp
@@ -113,7 +113,7 @@ int MyStrCmpI( const wchar_t* s1, const wchar_t* s2 )
 int main() // no C runtime, so no args here
 {
     g_hStdOut = GetStdHandle( STD_OUTPUT_HANDLE );
-    Print( L"Well hello there.\n" );
+ // Print( L"Well hello there.\n" );
 
     wchar_t* commandLineArgs = FindTheRestOfTheCommandLine();
 
@@ -123,7 +123,7 @@ int main() // no C runtime, so no args here
     //  2. Script URL.
     //  3. Expected script hash.
     //
-    // TODO: extra args
+    // Additional arguments are optional and will be passed along to the script.
     //
 
     wchar_t* cursor = commandLineArgs;
@@ -164,21 +164,28 @@ int main() // no C runtime, so no args here
 
     wchar_t* expectedScriptHash = cursor;
 
-    // TODO: optional/extra args
+    // *Optional* arguments.
+    cursor = SkipUntilWhitespace( cursor );
 
+    if( *cursor )
+    {
+        *cursor++ = L'\0';
+        cursor = SkipUntilNotWhitespace( cursor );
+    }
 
+    wchar_t* optionalArgs = cursor;
 
-    Print( L"Install mode: " );
-    Print( installMode );
-    Print( L"\n" );
+//  Print( L"Install mode: " );
+//  Print( installMode );
+//  Print( L"\n" );
 
-    Print( L"Script URL: " );
-    Print( scriptUrl );
-    Print( L"\n" );
+//  Print( L"Script URL: " );
+//  Print( scriptUrl );
+//  Print( L"\n" );
 
-    Print( L"Expected script hash: " );
-    Print( expectedScriptHash );
-    Print( L"\n" );
+//  Print( L"Expected script hash: " );
+//  Print( expectedScriptHash );
+//  Print( L"\n" );
 
     const wchar_t c_Silent[] = L"Silent";
     const wchar_t c_SilentWithProgress[] = L"SilentWithProgress";
@@ -197,28 +204,27 @@ int main() // no C runtime, so no args here
         //return -1;
     }
 
-    if( bIsSilent )
-    {
-        Print( L"Silent mode.\n" );
-    }
+//  if( bIsSilent )
+//  {
+//      Print( L"Silent mode.\n" );
+//  }
 
-    if( bIsSilentWithProgress )
-    {
-        Print( L"SilentWithProgress mode.\n" );
-    }
+//  if( bIsSilentWithProgress )
+//  {
+//      Print( L"SilentWithProgress mode.\n" );
+//  }
 
-    if( bIsInteractive )
-    {
-        Print( L"Interactive mode.\n" );
-    }
+//  if( bIsInteractive )
+//  {
+//      Print( L"Interactive mode.\n" );
+//  }
 
     wchar_t newCmdLine[ 4096 ];
     wchar_t* dst = newCmdLine;
     const wchar_t* pastEnd = &newCmdLine[ _countof( newCmdLine ) ];
 
-    const wchar_t cmdFrag0[] = L"-NoProfile -ExecutionPolicy RemoteSigned -Command $env:PSModulePath = $null ; "
+    const wchar_t cmdFrag0[] = L" -NoProfile -ExecutionPolicy RemoteSigned -Command $env:PSModulePath = $null ; "
                                L"try { "
-                                   L"$outerArgs = $args ; "
                                    L"$theScript = (iwr ";
 
     const wchar_t cmdFrag1[] =     L"$env:_POWERSHELL_STUB_TEST_URL_SUFFIX -UseBasic -EA Stop).Content ; "
@@ -229,76 +235,96 @@ int main() // no C runtime, so no args here
     const wchar_t cmdFrag2[] =     L"' ; "
                                    L"if( $hash -ne $expectedHash ) "
                                    L"{ "
-                                       L"throw \"Hash mismatch: expected $expectedHash but got $hash\" "
+                                       L"throw \\\"Hash mismatch: expected $expectedHash but got $hash\\\" "
                                    L"} ; "
                                    L"$sig = Get-AuthenticodeSignature -Source 'theScript.ps1' -Content $bytes ; "
                                    L"if( ($sig.Status -ne 'Valid') -and ($sig.Status -ne 'NotSigned') ) "
                                    L"{ "
-                                       L"throw \"Signature error: $($sig.Status)\" "
+                                       L"throw \\\"Signature error: $($sig.Status)\\\" "
                                    L"} ; "
-                                   L"Invoke-Expression \\\". { $theScript } -I  @outerArgs -EA Stop\\\" ; "
+                                   L"Invoke-Expression \\\". { $theScript } -";
+
+    const wchar_t cmdFrag3[] =     L" -EA Stop\\\" ; "
                                L"} catch { ";
 
+    const wchar_t cmdFrag4_Interactive[] =
+                                   L"Write-Host $_ -Fore Red ; "
+                                   L"$rsp = Read-Host 'pausing... [enter] to finish' ; "
+                                   L"if( $rsp -eq 'd' ) { $host.EnterNestedPrompt() } ; "
+                                   L"throw"
+                               L"}";
+
+    const wchar_t cmdFrag4_Silent[] =
+                                   L"Write-Host $_ -Fore Red ; "
+                                   L"Start-Sleep -Seconds 5 ; " // Give people a chance to at least see the error.
+                                   L"throw"
+                               L"}";
 
     dst = CopyStr( dst, cmdFrag0, pastEnd );
     dst = CopyStr( dst, scriptUrl, pastEnd );
     dst = CopyStr( dst, cmdFrag1, pastEnd );
     dst = CopyStr( dst, expectedScriptHash, pastEnd );
     dst = CopyStr( dst, cmdFrag2, pastEnd );
+    dst = CopyStr( dst, installMode, pastEnd );
+    dst = CopyStr( dst, L" ", pastEnd);
+    dst = CopyStr( dst, optionalArgs, pastEnd);
+    dst = CopyStr( dst, cmdFrag3, pastEnd );
 
-    Print( L"\n\nNew command: " );
-    Print( newCmdLine );
+    if( bIsInteractive )
+    {
+        dst = CopyStr( dst, cmdFrag4_Interactive, pastEnd );
+    }
+    else
+    {
+        dst = CopyStr( dst, cmdFrag4_Silent, pastEnd );
+    }
 
+ // Print( L"\nCommandline: " );
+ // Print( newCmdLine );
+ // Print( L"\n\n" );
 
+    PROCESS_INFORMATION pi = { };
+    STARTUPINFOW si;
+    SecureZeroMemory( &si, sizeof( si ) ); // compiler complained about no memset; whatevs
+    si.cb = (DWORD) sizeof( si );
 
-    ExitProcess( 0 );
- // return 0;
+    const wchar_t* wszPowershellExe = L"C:\\Windows\\system32\\WindowsPowerShell\\v1.0\\powershell.exe";
 
- // PROCESS_INFORMATION pi = { };
- // STARTUPINFOW si;
- // SecureZeroMemory( &si, sizeof( si ) ); // compiler complained about no memset; whatevs
- // si.cb = (DWORD) sizeof( si );
+    BOOL bItWorked = CreateProcessW( wszPowershellExe,
+                                     newCmdLine,
+                                     nullptr,   // lpProcessAttributes
+                                     nullptr,   // lpThreadAttributes
+                                     TRUE,      // bInheritHandles
+                                     0,         // dwFlags
+                                     nullptr,   // lpEnvironment
+                                     nullptr,   // lpCurrentDirectory
+                                     &si,
+                                     &pi );
 
- // const wchar_t* wszPowershellExe = L"C:\\Windows\\system32\\WindowsPowerShell\\v1.0\\powershell.exe";
+    if( !bItWorked )
+    {
+        ExitProcess( GetLastError() );
+    }
 
- // BOOL bItWorked = CreateProcessW( wszPowershellExe,
- //                                  commandLineArgs,
- //                                  nullptr,   // lpProcessAttributes
- //                                  nullptr,   // lpThreadAttributes
- //                                  TRUE,      // bInheritHandles
- //                                  0,         // dwFlags
- //                                  nullptr,   // lpEnvironment
- //                                  nullptr,   // lpCurrentDirectory
- //                                  &si,
- //                                  &pi );
+    // Ignoring result...
+    WaitForSingleObject( pi.hProcess, INFINITE );
 
- // if( !bItWorked )
- // {
- //     ExitProcess( GetLastError() );
- //     //return -1; // unreachable
- // }
+    DWORD dwRet = 0;
+    bItWorked = GetExitCodeProcess( pi.hProcess, &dwRet );
 
- // // Ignoring result...
- // WaitForSingleObject( pi.hProcess, INFINITE );
+    CloseHandle( pi.hProcess );
+    CloseHandle( pi.hThread );
 
- // DWORD dwRet = 0;
- // bItWorked = GetExitCodeProcess( pi.hProcess, &dwRet );
+    if( !bItWorked )
+    {
+        ExitProcess( GetLastError() );
+    }
 
- // CloseHandle( pi.hProcess );
- // CloseHandle( pi.hThread );
-
- // if( !bItWorked )
- // {
- //     ExitProcess( GetLastError() );
- //     //return -1; // unreachable
- // }
-
- // // Note that we use ExitProcess to end execution instead of just "return dwRet",
- // // because returning from main leads to running RtlExitUserThread, and when running on
- // // an ARM64 machine, that was failing in a bizarre way (it appeared that the return
- // // code was not being propagated--one speculation was that it might be returning the
- // // thread's exit code instead of main's--and when running under a debugger to
- // // investigate, the debugger would get stuck and you couldn't break in).
- // ExitProcess( dwRet );
-    //return -1; // unreachable
+    // Note that we use ExitProcess to end execution instead of just "return dwRet",
+    // because returning from main leads to running RtlExitUserThread, and when running on
+    // an ARM64 machine, that was failing in a bizarre way (it appeared that the return
+    // code was not being propagated--one speculation was that it might be returning the
+    // thread's exit code instead of main's--and when running under a debugger to
+    // investigate, the debugger would get stuck and you couldn't break in).
+    ExitProcess( dwRet );
 }

--- a/main.cpp
+++ b/main.cpp
@@ -75,7 +75,9 @@ HANDLE g_hStdOut = 0;
 
 #define _countof(_Array) ((sizeof(_Array) / sizeof(_Array[0])))
 
-DWORD MyWcslen( const wchar_t* s )
+// TODO: does this really evaluate at compile-time, or do I need to switch to a recursive
+// method?
+constexpr DWORD MyWcslen( const wchar_t* s )
 {
     DWORD cch = 0;
     while( *s )
@@ -90,6 +92,24 @@ void Print( const wchar_t* s )
 {
     WriteConsoleW( g_hStdOut, s, MyWcslen( s ), nullptr, nullptr );
 } // end Print()
+
+int MyStrCmpI( const wchar_t* s1, const wchar_t* s2 )
+{
+    int ret = CompareStringOrdinal(s1, -1, s2, -1, TRUE);
+
+    if( !ret )
+    {
+        DWORD dwErr = GetLastError();
+        Print( L"Something went wrong.");
+        ExitProcess(dwErr);
+        return 0; // unreachable
+    }
+
+    // From CompareStringOrdinal documentation: "the value 2 can be subtracted
+    // from a nonzero return value. Then, the meaning of <0, ==0, and >0 is
+    // consistent with the C runtime."
+    return ret - 2;
+}
 
 int main() // no C runtime, so no args here
 {
@@ -122,6 +142,10 @@ int main() // no C runtime, so no args here
                                    L"} ; "
                                    L"Invoke-Expression \\\". { $theScript } -I  @outerArgs -EA Stop\\\" ; "
                                L"} catch { ";
+
+    const wchar_t c_Silent[] = L"Silent";
+    const wchar_t c_SilentWithProgress[] = L"SilentWithProgress";
+    const wchar_t c_Interactive[] = L"Interactive";
 
     dst = CopyStr( dst, L"", pastEnd );
 
@@ -190,6 +214,34 @@ int main() // no C runtime, so no args here
     Print( L"Expected script hash: " );
     Print( expectedScriptHash );
     Print( L"\n" );
+
+    bool bIsSilent = 0 == MyStrCmpI( installMode, c_Silent );
+    bool bIsSilentWithProgress = 0 == MyStrCmpI( installMode, c_SilentWithProgress );
+    bool bIsInteractive = 0 == MyStrCmpI( installMode, c_Interactive );
+
+    if( !bIsSilent && !bIsSilentWithProgress && !bIsInteractive )
+    {
+        Print( L"Install mode must be one of Silent, SilentWithProgress, or Interactive. Not '" );
+        Print( installMode );
+        Print( L"'.\n" );
+        ExitProcess( -1 );
+        return -1;
+    }
+
+    if( bIsSilent )
+    {
+        Print( L"Silent mode.\n" );
+    }
+
+    if( bIsSilentWithProgress )
+    {
+        Print( L"SilentWithProgress mode.\n" );
+    }
+
+    if( bIsInteractive )
+    {
+        Print( L"Interactive mode.\n" );
+    }
 
     ExitProcess( 0 );
     return 0;

--- a/main.cpp
+++ b/main.cpp
@@ -128,6 +128,8 @@ bool _HandleUsageRequest( const char8_t* installMode )
                u8"The value of the environment variable $env:_POWERSHELL_STUB_TEST_URL_SUFFIX is appended to the ScriptUrl.\n"
                u8"This is handy for testing a new version of the install script without having to update the winget package.\n"
                u8"\n"
+               u8"The install script is executed directly from memory; not saved to a temporary file.\n"
+               u8"\n"
                u8"The winget install mode is passed as a switch parameter to the script (e.g. -Silent), followed by the optional\n"
                u8"parameters, followed by -EA Stop (all errors are treated as terminating errors).\n"
                u8"\n"
@@ -188,6 +190,9 @@ void PrettyPrint( char8_t* s )
             s++;
         }
     };
+
+    printIndent();
+    Print( u8"powershell.exe" );
 
     while( *s )
     {
@@ -425,7 +430,7 @@ int main() // no C runtime, so no args here
     if( whatIf )
     {
         Print( u8"\nWould run powershell.exe with a command line to run the following code:\n" );
-        Print( u8"(use 'WhatIfRaw' instead to see the unmodified command line arguments)\n\n   " );
+        Print( u8"(use 'WhatIfRaw' instead to see the unmodified command line arguments)\n\n" );
         PrettyPrint( newCmdLine );
         Print( u8"\n\n" );
         ExitProcess( (UINT) -4 );


### PR DESCRIPTION
Previously, `PowerShellStub.exe` was extremely "loose": it allowed the caller to completely specify the command line to pass along to `powershell.exe`. So you could use it to, for example, download an arbitrary `.ps1` script and run it, or... anything else you liked.

Specifically, when used as a WinGet installer, this didn't honor the spirit of the general policy against "dynamic content". This change makes it a much better citizen: instead of just passing the rest of its command line along to `powershell.exe`, it now requires a much more rigid command line--to be used as a WinGet installer, you must pass three things:

1. The WinGet install mode (`Interactive`, `Silent`, or `SilentWithProgress`).
2. The URL of the script to download.
3. The expected hash of the downloaded script.

It then launches `powershell.exe` with a standardized wrapper script that downloads the specified target script, validates the hash, validates a signature (if present), and runs in a more standard way. This newly-required hash validation is the same strategy used by WinGet itself for installer packages, making this new version of PowerShellStub a much more appropriate WinGet installer.

More details in the new ReadMe.